### PR TITLE
Fix a big introduced in PR #13

### DIFF
--- a/app/models/experiment.rb
+++ b/app/models/experiment.rb
@@ -94,7 +94,7 @@ class Experiment < ApplicationRecord
   end
 
   def variants_by_proportions
-    return [] unless variants.empty?
+    return [] if variants.empty?
 
     choices = choose_n_times(alphabeta, 1000)
     choices.map! { |c| c.to_f / 1000 }


### PR DESCRIPTION
Rubocop was complaining about `unless variants.count > 0`
which got changed to `unless variants.empty?
which flipped logic`

This fixes that by changing the unless to if

So `unless variants.count > 0`
becomes `if variants.empty?`